### PR TITLE
Make SmscTimestamp members readable.

### DIFF
--- a/src/pdu.rs
+++ b/src/pdu.rs
@@ -518,14 +518,14 @@ impl From<u8> for DeliverPduFirstOctet {
 /// Service centre timestamp.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SmscTimestamp {
-    year: u8,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
+    pub year: u8,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
     /// Hours' difference between local time and GMT.
-    timezone: u8
+    pub timezone: u8
 }
 pub(crate) fn reverse_byte(b: u8) -> u8 {
     let units = b >> 4;


### PR DESCRIPTION
Hi,

I'm writing a tool [0] to access memory dumps of dumbphones and I'm using huawei-modem to parse SMS PDUs. I ran into a few issues - the first one being that the timestamp data isn't accessible and there are no getters. I'm sending this pull request first since it is a fairly simple one.

Other issues I've addressed / hacked in my copy of huawei-modem:

* SMS text isn't properly terminated and has garbage at the end
* Add a parser for sent SMS (Pdu::TryFrom &[u8])
* tokio-file-unix is in the way of windows builds and I don't need to access /dev/ nodes. A feature flag would be useful

I'll send more pull requests if I get a response to this PR

0: https://gitlab.com/stefandoesinger/dumbsync