### PR TITLE
Limit SMS text according to user data len

### DIFF
--- a/src/gsm_encoding/mod.rs
+++ b/src/gsm_encoding/mod.rs
@@ -179,8 +179,11 @@ impl GsmMessageData {
             },
             MessageEncoding::Ucs2 => {
                 Ok(DecodedMessage {
-                    text: UTF_16BE.decode(&self.bytes[start..], DecoderTrap::Replace).unwrap(),
-                    udh
+                    // We don't have to cut away a possible user data header length here because
+                    // "start" is incremented accordingly above and the user data ends after
+                    // user_data_len bytes with or without the header.
+                    text: UTF_16BE.decode(&self.bytes[start..self.user_data_len as usize],
+                    DecoderTrap::Replace).unwrap(), udh
                 })
             },
             x => Err(HuaweiError::UnsupportedEncoding(x, self.bytes.clone()))


### PR DESCRIPTION
These patches avoid garbage at the end of decoded SMS. In case of talking to an AT modem, the modem probably terminates the PDU with a \r\n at the appropriate place. But with messages taken from storage I don't know where they end. Some of the phones keep remains of old SMS in storage when they overwrite an old SMS with a shorter new one.

I am not entirely sure about my handling of the optional user data header - see the "Why the extra +1?". Without taking away an extra byte from the length, I got an extra random garbage character at the end of 7 bit SMS.

There is one further thing I am not sure about here, and it is not included in the MR but might be relevant for review: Situations where a UDH is present and the calculated padding is 7, the first letter was missing:

```
+            /* FIXME: This is another hack I built because it gave the right result, but I don't
+             * understand. Some messages were missing their first letter otherwise. */
+            if padding == 7
+            {
+                padding = 0;
+            }
```
